### PR TITLE
feat: add 'created_at' property when creating namespaces

### DIFF
--- a/logic/ns.go
+++ b/logic/ns.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -130,7 +131,7 @@ func (qtx *Tx) CreateNamespace(ctx context.Context, ns NamespaceContent) error {
 	}
 
 	if _, exists := ns.Properties["created_at"]; !exists {
-		ns.Properties["created_at"] = time.Now().Format(time.RFC3339)
+		ns.Properties["created_at"] = strconv.FormatInt(time.Now().UnixMilli(), 10)
 	}
 
 	for key, value := range ns.Properties {

--- a/logic/ns.go
+++ b/logic/ns.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/Bodo-inc/denali/common"
 )
@@ -126,6 +127,10 @@ func (qtx *Tx) CreateNamespace(ctx context.Context, ns NamespaceContent) error {
 			return &NamespaceAlreadyExistsError{Path: ns.ID}
 		}
 		return err
+	}
+
+	if _, exists := ns.Properties["created_at"]; !exists {
+		ns.Properties["created_at"] = time.Now().Format(time.RFC3339)
 	}
 
 	for key, value := range ns.Properties {


### PR DESCRIPTION
- Check if 'created_at' key exists in namespace properties.
- Add 'created_at' key with the current timestamp if it doesn't exist.

Closes #6 